### PR TITLE
feat(home): connect search input to /search (closes #55)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,5 +1,5 @@
 import { Image } from "expo-image";
-import { Link } from "expo-router";
+import { Link, router } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { useMemo, useState } from "react";
 import { Pressable, ScrollView, StyleSheet, TextInput, View } from "react-native";
@@ -112,6 +112,10 @@ export default function HomeScreen() {
             }
             value={query}
             onChangeText={setQuery}
+            onFocus={() => {
+              // ISSUE #55: a busca “vive” em /search
+              router.push("/search");
+            }}
             style={[
               styles.searchInput,
               {

--- a/app/search.tsx
+++ b/app/search.tsx
@@ -1,0 +1,226 @@
+import { Stack, router } from "expo-router";
+import { StatusBar } from "expo-status-bar";
+import { useEffect, useMemo, useState } from "react";
+import { Pressable, ScrollView, StyleSheet, TextInput, View } from "react-native";
+
+import { ProductCard } from "../components/product-card";
+import { ThemedText } from "../components/themed-text";
+import { ThemedView } from "../components/themed-view";
+import { categories, products } from "../constants/products";
+import theme from "../constants/theme";
+import { track } from "../lib/analytics";
+import { useColorScheme } from "../hooks/use-color-scheme";
+
+export default function SearchScreen() {
+  const colorScheme = useColorScheme() ?? "light";
+  const [query, setQuery] = useState("");
+  const [selectedCategory, setSelectedCategory] =
+    useState<(typeof categories)[number]>("Todos");
+
+  useEffect(() => {
+    try {
+      track("search_viewed");
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    const q = query.trim();
+    if (q.length < 2) return;
+
+    try {
+      track("search_query_changed", { q_len: q.length });
+    } catch {}
+  }, [query]);
+
+  const filteredProducts = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+
+    return products.filter((product) => {
+      const matchesCategory =
+        selectedCategory === "Todos" || product.category === selectedCategory;
+
+      const matchesQuery =
+        normalizedQuery.length === 0 ||
+        product.name.toLowerCase().includes(normalizedQuery) ||
+        product.description.toLowerCase().includes(normalizedQuery);
+
+      return matchesCategory && matchesQuery;
+    });
+  }, [query, selectedCategory]);
+
+  return (
+    <>
+      <StatusBar style="dark" />
+      <Stack.Screen
+        options={{
+          title: "Buscar",
+          headerTitleStyle: { fontWeight: "800" },
+          headerShadowVisible: false,
+          headerStyle: { backgroundColor: theme.colors.background },
+        }}
+      />
+
+      <ThemedView style={styles.root}>
+        <ThemedView style={styles.searchSection}>
+          <TextInput
+            placeholder="Buscar por categoria ou produto"
+            placeholderTextColor={
+              colorScheme === "light" ? "#6B7280" : "#9CA3AF"
+            }
+            value={query}
+            onChangeText={setQuery}
+            autoFocus
+            returnKeyType="search"
+            style={[
+              styles.searchInput,
+              {
+                backgroundColor:
+                  colorScheme === "light" ? "#F3F4F6" : "#111315",
+                borderColor: colorScheme === "light" ? "#E5E7EB" : "#2A2F38",
+                color: colorScheme === "light" ? "#111827" : "#F9FAFB",
+              },
+            ]}
+          />
+
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            style={styles.chipRow}
+            contentContainerStyle={styles.chipRowContent}
+          >
+            {categories.map((category) => {
+              const isSelected = selectedCategory === category;
+
+              return (
+                <Pressable
+                  key={category}
+                  onPress={() => setSelectedCategory(category)}
+                  style={[styles.chip, isSelected && styles.chipSelected]}
+                >
+                  <ThemedText
+                    type="caption"
+                    style={[
+                      styles.chipText,
+                      isSelected ? styles.chipSelectedText : undefined,
+                    ]}
+                  >
+                    {category}
+                  </ThemedText>
+                </Pressable>
+              );
+            })}
+          </ScrollView>
+
+          <View style={styles.sectionHeader}>
+            <ThemedText type="sectionTitle">Resultados</ThemedText>
+            <ThemedText type="caption">{filteredProducts.length} itens</ThemedText>
+          </View>
+        </ThemedView>
+
+        <View style={styles.grid}>
+          {filteredProducts.map((product) => (
+            <View key={product.id} style={styles.gridItem}>
+              <ProductCard product={product} />
+            </View>
+          ))}
+
+          {filteredProducts.length === 0 ? (
+            <ThemedText type="bodySmall">
+              Não encontramos itens para sua busca.
+            </ThemedText>
+          ) : null}
+        </View>
+
+        <Pressable onPress={() => router.back()} style={styles.backCta}>
+          <ThemedText type="defaultSemiBold" style={{ color: "#fff" }}>
+            Voltar
+          </ThemedText>
+        </Pressable>
+      </ThemedView>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    padding: 12,
+  },
+
+  searchSection: {
+    gap: 10,
+  },
+
+  sectionHeader: {
+    flexDirection: "row",
+    alignItems: "baseline",
+    justifyContent: "space-between",
+    marginTop: 2,
+  },
+
+  searchInput: {
+    width: "100%",
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    fontSize: 14,
+  },
+
+  chipRow: {
+    flexGrow: 0,
+  },
+
+  chipRowContent: {
+    paddingRight: 6,
+  },
+
+  chip: {
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 999,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: "#CBD5E1",
+    marginRight: 8,
+    minHeight: 34,
+    maxWidth: 140,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+
+  chipText: {
+    textAlign: "center",
+    lineHeight: 14,
+  },
+
+  chipSelected: {
+    backgroundColor: "#0a7ea4",
+    borderColor: "#0a7ea4",
+  },
+
+  chipSelectedText: {
+    color: "#fff",
+  },
+
+  grid: {
+    marginTop: 12,
+    flexDirection: "row",
+    flexWrap: "wrap",
+    marginHorizontal: -6,
+  },
+
+  gridItem: {
+    width: "50%",
+    paddingHorizontal: 6,
+    paddingBottom: 12,
+  },
+
+  backCta: {
+    marginTop: 8,
+    alignSelf: "center",
+    backgroundColor: "#0a7ea4",
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    borderRadius: 999,
+  },
+});


### PR DESCRIPTION
Contexto

A Issue #55 pede conectar a busca da Home para uma rota dedicada de busca (/search).

O que foi feito

Criada a rota app/search.tsx com:

input de busca + filtro por categoria

grid de produtos reutilizando ProductCard

Home (app/(tabs)/index.tsx):

ao focar no campo “Buscar por categoria ou produto”, redireciona para /search

Telemetria

Evento: search_viewed

Evento: search_query_changed (somente quando query ≥ 2 caracteres)

Como testar

Rodar:

npm run lint

npx tsc --noEmit

No app:

abrir Home

tocar no campo de busca → deve navegar para /search

digitar → resultados filtram

voltar → retorna à Home sem crash

Risco / rollback

Risk-low (mudança isolada em navegação + nova tela)

Rollback: revert do PR

Closes

Closes #55