### PR TITLE
chore(analytics): standardize PDP source for ProductCard (home/search)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -2,7 +2,13 @@ import { Image } from "expo-image";
 import { Link, router } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { useMemo, useState } from "react";
-import { Pressable, ScrollView, StyleSheet, TextInput, View } from "react-native";
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  TextInput,
+  View,
+} from "react-native";
 
 import ParallaxScrollView from "../../components/parallax-scroll-view";
 import { ProductCard } from "../../components/product-card";
@@ -160,7 +166,7 @@ export default function HomeScreen() {
         <View style={styles.grid}>
           {filteredProducts.map((product) => (
             <View key={product.id} style={styles.gridItem}>
-              <ProductCard product={product} />
+              <ProductCard product={product} source="home" />
             </View>
           ))}
 

--- a/app/search.tsx
+++ b/app/search.tsx
@@ -1,15 +1,21 @@
 import { Stack, router } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { useEffect, useMemo, useState } from "react";
-import { Pressable, ScrollView, StyleSheet, TextInput, View } from "react-native";
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  TextInput,
+  View,
+} from "react-native";
 
 import { ProductCard } from "../components/product-card";
 import { ThemedText } from "../components/themed-text";
 import { ThemedView } from "../components/themed-view";
 import { categories, products } from "../constants/products";
 import theme from "../constants/theme";
-import { track } from "../lib/analytics";
 import { useColorScheme } from "../hooks/use-color-scheme";
+import { track } from "../lib/analytics";
 
 export default function SearchScreen() {
   const colorScheme = useColorScheme() ?? "light";
@@ -113,14 +119,16 @@ export default function SearchScreen() {
 
           <View style={styles.sectionHeader}>
             <ThemedText type="sectionTitle">Resultados</ThemedText>
-            <ThemedText type="caption">{filteredProducts.length} itens</ThemedText>
+            <ThemedText type="caption">
+              {filteredProducts.length} itens
+            </ThemedText>
           </View>
         </ThemedView>
 
         <View style={styles.grid}>
           {filteredProducts.map((product) => (
             <View key={product.id} style={styles.gridItem}>
-              <ProductCard product={product} />
+              <ProductCard product={product} source="search" />
             </View>
           ))}
 

--- a/components/product-card.tsx
+++ b/components/product-card.tsx
@@ -11,7 +11,7 @@ import { useThemeColor } from "@/hooks/use-theme-color";
 
 type ProductCardProps = {
   product: Product;
-  source?: "home" | "explore" | "unknown";
+  source?: "home" | "explore" | "search" | "category" | "unknown";
 };
 
 function formatBRL(value: number) {
@@ -61,7 +61,10 @@ export function ProductCard({ product, source = "unknown" }: ProductCardProps) {
   }
 
   return (
-    <Pressable onPress={handleOpen} style={({ pressed }) => pressed ? { opacity: 0.96 } : null}>
+    <Pressable
+      onPress={handleOpen}
+      style={({ pressed }) => (pressed ? { opacity: 0.96 } : null)}
+    >
       <ThemedView
         style={[styles.card, { backgroundColor: cardBg, borderColor: border }]}
       >


### PR DESCRIPTION
Contexto

A PDP usa source, mas Home e Search estavam abrindo PDP via ProductCard sem source, resultando em "unknown".

O que foi feito

ProductCard agora aceita source: "home" | "explore" | "search" | "category" | "unknown".

Home passa source="home" ao renderizar cards.

Search passa source="search" ao renderizar cards.

Como testar

Home → abrir produto → PDP recebe source=home

Search → abrir produto → PDP recebe source=search

npm run lint + npx tsc --noEmit

Risco / rollback

risk-low (apenas params de rota)

rollback: revert do PR