### PR TITLE
chore(analytics): pass source=home to ProductCard in Home (closes #97)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,8 +1,8 @@
 // app/(tabs)/index.tsx
 import { Image } from "expo-image";
-import { Link, router } from "expo-router";
+import { Link, router, useFocusEffect } from "expo-router";
 import { StatusBar } from "expo-status-bar";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import {
   Pressable,
   ScrollView,
@@ -14,7 +14,6 @@ import {
 
 import ParallaxScrollView from "../../components/parallax-scroll-view";
 import { ProductCard } from "../../components/product-card";
-import { isFlagEnabled } from "../../constants/flags";
 import { categories, products } from "../../constants/products";
 import { useColorScheme } from "../../hooks/use-color-scheme";
 import { track } from "../../lib/analytics";
@@ -22,11 +21,6 @@ import { track } from "../../lib/analytics";
 // fail-safe + outbox flush
 import { useCheckoutFailSafe } from "../../hooks/useCheckoutFailSafe";
 import { useOutboxAutoFlush } from "../../hooks/useOutboxAutoFlush";
-
-function formatBRL(value: number) {
-  const v = Number.isFinite(value) ? value : 0;
-  return `R$ ${v.toFixed(2).replace(".", ",")}`;
-}
 
 export default function HomeScreen() {
   useCheckoutFailSafe();
@@ -38,6 +32,17 @@ export default function HomeScreen() {
   const [query, setQuery] = useState("");
   const [selectedCategory, setSelectedCategory] =
     useState<(typeof categories)[number]>("Todos");
+
+  // evita disparo múltiplo do onFocus em re-render/teclado
+  const didRedirectRef = useRef(false);
+
+  // ao voltar pra Home (ex: back do /search), permite redirecionar de novo
+  useFocusEffect(
+    useCallback(() => {
+      didRedirectRef.current = false;
+      return () => {};
+    }, []),
+  );
 
   const filteredProducts = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
@@ -56,44 +61,6 @@ export default function HomeScreen() {
   }, [query, selectedCategory]);
 
   const headerBg = "#0E1720";
-
-  // ===== Achadinhos (Ticket #27) =====
-  const achadinhosEnabled = isFlagEnabled("ff_home_achadinhos_v1");
-  const achadinhosViewedRef = useRef(false);
-
-  const achadinhos = useMemo(() => {
-    // Curadoria local: prioriza itens com badge, depois completa com os primeiros
-    const withBadge = products.filter((p) => !!(p as any).badge);
-    const rest = products.filter((p) => !(p as any).badge);
-
-    const merged = [...withBadge, ...rest].slice(0, 8);
-    return merged;
-  }, []);
-
-  useEffect(() => {
-    if (!achadinhosEnabled) return;
-    if (achadinhosViewedRef.current) return;
-    if (!achadinhos.length) return;
-
-    achadinhosViewedRef.current = true;
-    try {
-      track("home_achadinhos_viewed", { items_count: achadinhos.length });
-    } catch {}
-  }, [achadinhosEnabled, achadinhos.length]);
-
-  function openAchadinho(productId: string, position: number) {
-    try {
-      track("home_achadinho_clicked", {
-        product_id: String(productId),
-        position,
-      });
-    } catch {}
-
-    router.push({
-      pathname: "/product/[id]" as any,
-      params: { id: String(productId), source: "home" },
-    } as any);
-  }
 
   return (
     <>
@@ -135,6 +102,19 @@ export default function HomeScreen() {
               placeholderTextColor={isLight ? "#64748B" : "#94A3B8"}
               value={query}
               onChangeText={setQuery}
+              onFocus={() => {
+                // Home: busca “vive” em /search
+                if (didRedirectRef.current) return;
+                didRedirectRef.current = true;
+
+                try {
+                  track("home_search_focused", {
+                    source: "home_search_input",
+                  });
+                } catch {}
+
+                router.push("/search");
+              }}
               style={[
                 styles.searchInput,
                 { color: isLight ? "#0B1220" : "#F8FAFC" },
@@ -164,19 +144,19 @@ export default function HomeScreen() {
                       backgroundColor: isSelected
                         ? "#0A7EA4"
                         : isLight
-                        ? "#FFFFFF"
-                        : "#0B1220",
+                          ? "#FFFFFF"
+                          : "#0B1220",
                       borderColor: isSelected
                         ? "#0A7EA4"
                         : isLight
-                        ? "#E2E8F0"
-                        : "#1F2937",
+                          ? "#E2E8F0"
+                          : "#1F2937",
                     },
                   ]}
                   accessibilityRole="button"
                   accessibilityLabel={`Categoria ${category}`}
                 >
-                  {/* IMPORTANTe: sem numberOfLines -> sem "..." */}
+                  {/* IMPORTANTE: sem numberOfLines -> sem "..." */}
                   <Text
                     style={[
                       styles.chipText,
@@ -184,8 +164,8 @@ export default function HomeScreen() {
                         color: isSelected
                           ? "#FFFFFF"
                           : isLight
-                          ? "#0B1220"
-                          : "#E5E7EB",
+                            ? "#0B1220"
+                            : "#E5E7EB",
                       },
                     ]}
                   >
@@ -245,87 +225,6 @@ export default function HomeScreen() {
           <View style={styles.heroNeutralBox} />
         </View>
 
-        {/* Achadinhos do Dia (Ticket #27) */}
-        {achadinhosEnabled ? (
-          <View style={styles.achadinhosBlock}>
-            <View style={styles.achadinhosHeader}>
-              <Text
-                style={[
-                  styles.achadinhosTitle,
-                  { color: isLight ? "#0B1220" : "#F8FAFC" },
-                ]}
-              >
-                Achadinhos do Dia
-              </Text>
-              <Text
-                style={[
-                  styles.achadinhosMeta,
-                  { color: isLight ? "#64748B" : "#94A3B8" },
-                ]}
-              >
-                {achadinhos.length} sugestões
-              </Text>
-            </View>
-
-            <ScrollView
-              horizontal
-              showsHorizontalScrollIndicator={false}
-              contentContainerStyle={styles.achadinhosRow}
-            >
-              {achadinhos.map((p, idx) => (
-                <Pressable
-                  key={p.id}
-                  onPress={() => openAchadinho(p.id, idx + 1)}
-                  style={[
-                    styles.achadinhoCard,
-                    {
-                      backgroundColor: isLight ? "#FFFFFF" : "#0B1220",
-                      borderColor: isLight ? "#E2E8F0" : "#1F2937",
-                    },
-                  ]}
-                >
-                  <Image
-                    source={{ uri: p.image }}
-                    style={styles.achadinhoImage}
-                    contentFit="cover"
-                    transition={120}
-                  />
-
-                  <Text
-                    numberOfLines={2}
-                    style={[
-                      styles.achadinhoName,
-                      { color: isLight ? "#0B1220" : "#F8FAFC" },
-                    ]}
-                  >
-                    {p.name}
-                  </Text>
-
-                  <Text
-                    style={[
-                      styles.achadinhoPrice,
-                      { color: isLight ? "#0A7EA4" : "#7AC4FF" },
-                    ]}
-                  >
-                    {formatBRL(p.price)}
-                  </Text>
-
-                  {(p as any).badge ? (
-                    <Text
-                      style={[
-                        styles.achadinhoBadge,
-                        { color: isLight ? "#0B1220" : "#E5E7EB" },
-                      ]}
-                    >
-                      {(p as any).badge}
-                    </Text>
-                  ) : null}
-                </Pressable>
-              ))}
-            </ScrollView>
-          </View>
-        ) : null}
-
         {/* Catálogo */}
         <View style={styles.catalogHeader}>
           <Text
@@ -348,7 +247,7 @@ export default function HomeScreen() {
 
         <View style={styles.grid}>
           {filteredProducts.map((product) => (
-            <ProductCard key={product.id} product={product} />
+            <ProductCard key={product.id} product={product} source="home" />
           ))}
 
           {filteredProducts.length === 0 ? (
@@ -488,65 +387,6 @@ const styles = StyleSheet.create({
     height: 74,
     borderRadius: 18,
     backgroundColor: "rgba(148,163,184,0.25)",
-  },
-
-  achadinhosBlock: {
-    marginTop: 14,
-    gap: 10,
-  },
-
-  achadinhosHeader: {
-    flexDirection: "row",
-    alignItems: "baseline",
-    justifyContent: "space-between",
-  },
-
-  achadinhosTitle: {
-    fontSize: 18,
-    fontWeight: "900",
-    letterSpacing: -0.2,
-  },
-
-  achadinhosMeta: {
-    fontSize: 12,
-    fontWeight: "700",
-  },
-
-  achadinhosRow: {
-    gap: 10,
-    paddingVertical: 2,
-  },
-
-  achadinhoCard: {
-    width: 186,
-    borderRadius: 14,
-    borderWidth: 1,
-    padding: 10,
-    gap: 6,
-  },
-
-  achadinhoImage: {
-    width: "100%",
-    height: 110,
-    borderRadius: 12,
-    backgroundColor: "rgba(148,163,184,0.20)",
-  },
-
-  achadinhoName: {
-    fontSize: 13,
-    fontWeight: "900",
-    letterSpacing: -0.1,
-  },
-
-  achadinhoPrice: {
-    fontSize: 13,
-    fontWeight: "900",
-  },
-
-  achadinhoBadge: {
-    fontSize: 11,
-    fontWeight: "800",
-    opacity: 0.8,
   },
 
   catalogHeader: {


### PR DESCRIPTION
Padroniza origem do PDP/telemetria: ProductCard na Home abre PDP com source=home. Sem mudança de layout.

Métricas:
- (já existente no ProductCard/PDP) source=home

Gates:
- npm run lint
- npx tsc --noEmit

Rollback:
- Reverter o PR.