### PR TITLE
feat(home): UI branca + header azul fixo com endereço e departamentos

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,42 +1,33 @@
 // app/(tabs)/index.tsx
-import { Image } from "expo-image";
 import { Link, router, useFocusEffect } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { useCallback, useMemo, useRef, useState } from "react";
-import {
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  TextInput,
-  View,
-} from "react-native";
+import { Pressable, ScrollView, StyleSheet, Text, TextInput, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
-import ParallaxScrollView from "../../components/parallax-scroll-view";
 import { ProductCard } from "../../components/product-card";
 import { categories, products } from "../../constants/products";
-import { useColorScheme } from "../../hooks/use-color-scheme";
 import { track } from "../../lib/analytics";
 
 // fail-safe + outbox flush
 import { useCheckoutFailSafe } from "../../hooks/useCheckoutFailSafe";
 import { useOutboxAutoFlush } from "../../hooks/useOutboxAutoFlush";
 
+type QuickAction = { id: string; label: string; emoji: string; bg: string; route: string };
+type Dept = { id: string; label: string; emoji: string };
+
 export default function HomeScreen() {
   useCheckoutFailSafe();
   useOutboxAutoFlush();
 
-  const colorScheme = useColorScheme() ?? "light";
-  const isLight = colorScheme === "light";
+  const insets = useSafeAreaInsets();
 
   const [query, setQuery] = useState("");
   const [selectedCategory, setSelectedCategory] =
     useState<(typeof categories)[number]>("Todos");
 
-  // evita disparo múltiplo do onFocus em re-render/teclado
   const didRedirectRef = useRef(false);
 
-  // ao voltar pra Home (ex: back do /search), permite redirecionar de novo
   useFocusEffect(
     useCallback(() => {
       didRedirectRef.current = false;
@@ -60,150 +51,200 @@ export default function HomeScreen() {
     });
   }, [query, selectedCategory]);
 
-  const headerBg = "#0E1720";
+  // “meio banner” azul fixo
+  const BLUE_HEADER_H = 190;
+
+  // mock (substituir por store real)
+  const buyerAddress = "Rua Exemplo, 123 • Centro • Curitiba-PR";
+
+  const quickActions: QuickAction[] = useMemo(
+    () => [
+      { id: "flash", label: "Relâmpagos", emoji: "⚡", bg: "#FFE7BA", route: "/explore" },
+      { id: "offers", label: "Ofertas", emoji: "🔥", bg: "#FFD6D6", route: "/explore" },
+      { id: "deals", label: "Descontos", emoji: "💸", bg: "#D7F8E4", route: "/explore" },
+      { id: "coupons", label: "Cupons", emoji: "🏷️", bg: "#DDEBFF", route: "/explore" },
+      { id: "official", label: "Oficiais", emoji: "✅", bg: "#E9D7FF", route: "/explore" },
+      { id: "shipping", label: "Frete", emoji: "🚚", bg: "#D7F3FF", route: "/explore" },
+    ],
+    [],
+  );
+
+  const departments: Dept[] = useMemo(
+    () => [
+      { id: "eletronicos", label: "Eletrônicos", emoji: "📱" },
+      { id: "casa", label: "Casa", emoji: "🏠" },
+      { id: "cozinha", label: "Cozinha", emoji: "🍳" },
+      { id: "beleza", label: "Beleza", emoji: "💄" },
+      { id: "ferramentas", label: "Ferramentas", emoji: "🧰" },
+      { id: "pets", label: "Pets", emoji: "🐾" },
+      { id: "moda", label: "Moda", emoji: "👕" },
+      { id: "esportes", label: "Esportes", emoji: "🏀" },
+      { id: "infantil", label: "Infantil", emoji: "🧸" },
+      { id: "automotivo", label: "Auto", emoji: "🚗" },
+      { id: "jardim", label: "Jardim", emoji: "🌿" },
+      { id: "iluminacao", label: "Iluminação", emoji: "💡" },
+    ],
+    [],
+  );
 
   return (
-    <>
-      <StatusBar style="light" />
+    <View style={styles.screen}>
+      <StatusBar style="dark" />
 
-      <ParallaxScrollView
-        headerBackgroundColor={{ light: headerBg, dark: headerBg }}
-        headerImage={
-          <Image
-            source={require("../../assets/banners/banner-home.png")}
-            style={styles.headerBanner}
-            contentFit="cover"
-            transition={120}
-          />
-        }
+      {/* Header azul FIXO (fica preso ao subir) */}
+      <View
+        style={[
+          styles.blueHeader,
+          {
+            paddingTop: insets.top + 10,
+            height: BLUE_HEADER_H + insets.top,
+          },
+        ]}
       >
-        {/* Top compact (ML-like): headline curto + busca + chips */}
-        <View style={styles.topBlock}>
-          <Text style={[styles.h1, { color: isLight ? "#0B1220" : "#F8FAFC" }]}>
-            Boas-vindas
-          </Text>
-
-          <Text style={[styles.p, { color: isLight ? "#475569" : "#CBD5E1" }]}>
-            Descubra itens com foco em operação e vitrine — rápido e direto.
-          </Text>
-
-          <View
-            style={[
-              styles.searchWrap,
-              {
-                backgroundColor: isLight ? "#F1F5F9" : "#0B1220",
-                borderColor: isLight ? "#E2E8F0" : "#1F2937",
-              },
-            ]}
+        <View style={styles.blueHeaderInner}>
+          <Pressable
+            style={styles.addressRow}
+            onPress={() => track("home_address_click")}
+            accessibilityRole="button"
           >
-            <Text style={styles.searchIcon}>🔎</Text>
-            <TextInput
-              placeholder="Buscar por categoria ou produto"
-              placeholderTextColor={isLight ? "#64748B" : "#94A3B8"}
-              value={query}
-              onChangeText={setQuery}
-              onFocus={() => {
-                // Home: busca “vive” em /search
-                if (didRedirectRef.current) return;
-                didRedirectRef.current = true;
-
-                try {
-                  track("home_search_focused", {
-                    source: "home_search_input",
-                  });
-                } catch {}
-
-                router.push("/search");
-              }}
-              style={[
-                styles.searchInput,
-                { color: isLight ? "#0B1220" : "#F8FAFC" },
-              ]}
-              returnKeyType="search"
-              autoCorrect={false}
-              autoCapitalize="none"
-              clearButtonMode="while-editing"
-            />
-          </View>
+            <Text style={styles.addressLabel}>Entregar em</Text>
+            <Text style={styles.addressValue} numberOfLines={1}>
+              {buyerAddress}
+            </Text>
+          </Pressable>
 
           <ScrollView
             horizontal
             showsHorizontalScrollIndicator={false}
-            contentContainerStyle={styles.chipsRow}
+            contentContainerStyle={styles.deptRow}
           >
-            {categories.map((category) => {
-              const isSelected = selectedCategory === category;
-
-              return (
-                <Pressable
-                  key={category}
-                  onPress={() => setSelectedCategory(category)}
-                  style={[
-                    styles.chip,
-                    {
-                      backgroundColor: isSelected
-                        ? "#0A7EA4"
-                        : isLight
-                          ? "#FFFFFF"
-                          : "#0B1220",
-                      borderColor: isSelected
-                        ? "#0A7EA4"
-                        : isLight
-                          ? "#E2E8F0"
-                          : "#1F2937",
-                    },
-                  ]}
-                  accessibilityRole="button"
-                  accessibilityLabel={`Categoria ${category}`}
-                >
-                  {/* IMPORTANTE: sem numberOfLines -> sem "..." */}
-                  <Text
-                    style={[
-                      styles.chipText,
-                      {
-                        color: isSelected
-                          ? "#FFFFFF"
-                          : isLight
-                            ? "#0B1220"
-                            : "#E5E7EB",
-                      },
-                    ]}
-                  >
-                    {category}
-                  </Text>
-                </Pressable>
-              );
-            })}
+            {departments.map((d) => (
+              <Pressable
+                key={d.id}
+                style={styles.deptPill}
+                onPress={() => {
+                  track("home_department_click", { id: d.id, label: d.label });
+                  router.push("/explore");
+                }}
+                accessibilityRole="button"
+              >
+                <View style={styles.deptIcon}>
+                  <Text style={styles.deptEmoji}>{d.emoji}</Text>
+                </View>
+                <Text style={styles.deptLabel} numberOfLines={1}>
+                  {d.label}
+                </Text>
+              </Pressable>
+            ))}
           </ScrollView>
         </View>
+      </View>
 
-        {/* Hero compacto, sem marca e sem banner-splash */}
-        <View
-          style={[
-            styles.hero,
-            {
-              backgroundColor: isLight ? "#E6F4FE" : "#0B1220",
-              borderColor: isLight ? "#DCEAF7" : "#1F2937",
-            },
-          ]}
+      {/* Conteúdo scrollável (passa “por baixo” do header fixo) */}
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={{
+          paddingTop: BLUE_HEADER_H + 12,
+          paddingBottom: 24 + insets.bottom,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Busca branca com letras pretas */}
+        <View style={styles.searchWrap}>
+          <Text style={styles.searchIcon}>🔎</Text>
+          <TextInput
+            placeholder="Buscar por categoria ou produto"
+            placeholderTextColor="#0B1220"
+            value={query}
+            onChangeText={setQuery}
+            onFocus={() => {
+              if (didRedirectRef.current) return;
+              didRedirectRef.current = true;
+
+              track("home_search_focused", { source: "home_search_input" });
+              router.push("/search");
+            }}
+            style={styles.searchInput}
+            returnKeyType="search"
+            autoCorrect={false}
+            autoCapitalize="none"
+            clearButtonMode="while-editing"
+          />
+        </View>
+
+        {/* Atalhos (ícones redondos) */}
+        <View style={styles.card}>
+          <View style={styles.sectionHeaderRow}>
+            <Text style={styles.sectionTitleSmall}>Atalhos</Text>
+            <Text style={styles.sectionMetaSmall}>Toque para explorar</Text>
+          </View>
+
+          <View style={styles.quickGrid}>
+            {quickActions.map((a) => (
+              <Pressable
+                key={a.id}
+                style={styles.quickItem}
+                onPress={() => {
+                  track("home_quick_action_click", { id: a.id, label: a.label });
+                  router.push(a.route);
+                }}
+                accessibilityRole="button"
+              >
+                <View style={[styles.quickIcon, { backgroundColor: a.bg }]}>
+                  <Text style={styles.quickEmoji}>{a.emoji}</Text>
+                </View>
+                <Text style={styles.quickLabel} numberOfLines={2}>
+                  {a.label}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+        </View>
+
+        {/* Chips categorias */}
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.chipsRow}
         >
+          {categories.map((category) => {
+            const isSelected = selectedCategory === category;
+
+            return (
+              <Pressable
+                key={category}
+                onPress={() => setSelectedCategory(category)}
+                style={[
+                  styles.chip,
+                  {
+                    backgroundColor: isSelected ? "#0A7EA4" : "#FFFFFF",
+                    borderColor: isSelected ? "#0A7EA4" : "#E2E8F0",
+                  },
+                ]}
+                accessibilityRole="button"
+                accessibilityLabel={`Categoria ${category}`}
+              >
+                <Text
+                  style={[
+                    styles.chipText,
+                    { color: isSelected ? "#FFFFFF" : "#0B1220" },
+                  ]}
+                >
+                  {category}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </ScrollView>
+
+        {/* Hero (claro) */}
+        <View style={[styles.hero, { backgroundColor: "#F3F7FF", borderColor: "#D6E4FF" }]}>
           <View style={{ flex: 1, gap: 6 }}>
-            <Text
-              style={[
-                styles.heroTitle,
-                { color: isLight ? "#0B1220" : "#F8FAFC" },
-              ]}
-            >
+            <Text style={[styles.heroTitle, { color: "#0B1220" }]}>
               Kit rápido de vitrine
             </Text>
-            <Text
-              style={[
-                styles.heroDesc,
-                { color: isLight ? "#334155" : "#CBD5E1" },
-              ]}
-            >
-              Organização, sinalização e iluminação para vender mais com menos
-              esforço.
+            <Text style={[styles.heroDesc, { color: "#334155" }]}>
+              Organização, sinalização e iluminação para vender mais com menos esforço.
             </Text>
 
             <View style={styles.heroActions}>
@@ -221,28 +262,13 @@ export default function HomeScreen() {
             </View>
           </View>
 
-          {/* Elemento neutro (sem logo) para manter equilíbrio visual */}
           <View style={styles.heroNeutralBox} />
         </View>
 
         {/* Catálogo */}
         <View style={styles.catalogHeader}>
-          <Text
-            style={[
-              styles.sectionTitle,
-              { color: isLight ? "#0B1220" : "#F8FAFC" },
-            ]}
-          >
-            Catálogo
-          </Text>
-          <Text
-            style={[
-              styles.sectionMeta,
-              { color: isLight ? "#64748B" : "#94A3B8" },
-            ]}
-          >
-            {filteredProducts.length} itens
-          </Text>
+          <Text style={styles.sectionTitle}>Catálogo</Text>
+          <Text style={styles.sectionMeta}>{filteredProducts.length} itens</Text>
         </View>
 
         <View style={styles.grid}>
@@ -251,43 +277,63 @@ export default function HomeScreen() {
           ))}
 
           {filteredProducts.length === 0 ? (
-            <Text
-              style={[
-                styles.empty,
-                { color: isLight ? "#64748B" : "#94A3B8" },
-              ]}
-            >
-              Não encontramos itens para sua busca.
-            </Text>
+            <Text style={styles.empty}>Não encontramos itens para sua busca.</Text>
           ) : null}
         </View>
-      </ParallaxScrollView>
-    </>
+
+        <View style={{ height: 12 }} />
+      </ScrollView>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  headerBanner: {
-    width: "100%",
-    height: "100%",
-  },
+  screen: { flex: 1, backgroundColor: "#FFFFFF" },
+  scroll: { flex: 1 },
 
-  topBlock: {
-    gap: 10,
-    marginBottom: 10,
+  // HEADER AZUL FIXO
+  blueHeader: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    top: 0,
+    zIndex: 20,
+    backgroundColor: "#0A7EA4",
+    borderBottomLeftRadius: 18,
+    borderBottomRightRadius: 18,
+    overflow: "hidden",
   },
-
-  h1: {
-    fontSize: 26,
-    fontWeight: "900",
-    letterSpacing: -0.3,
+  blueHeaderInner: {
+    paddingHorizontal: 14,
+    gap: 12,
   },
-
-  p: {
-    fontSize: 13,
-    lineHeight: 18,
+  addressRow: {
+    backgroundColor: "rgba(255,255,255,0.22)",
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.25)",
+    borderRadius: 14,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
   },
+  addressLabel: { color: "#FFFFFF", fontSize: 10, fontWeight: "900", opacity: 0.95 },
+  addressValue: { color: "#FFFFFF", fontSize: 11, fontWeight: "800", marginTop: 4 },
 
+  deptRow: { gap: 10, paddingBottom: 12 },
+  deptPill: { width: 72, alignItems: "center", gap: 6 },
+  deptIcon: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "rgba(255,255,255,0.95)",
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.40)",
+  },
+  deptEmoji: { fontSize: 18 },
+  deptLabel: { color: "#FFFFFF", fontSize: 10, fontWeight: "900" },
+
+  // Busca branca com letras pretas
   searchWrap: {
     flexDirection: "row",
     alignItems: "center",
@@ -295,58 +341,68 @@ const styles = StyleSheet.create({
     borderRadius: 14,
     paddingHorizontal: 10,
     height: 44,
+    backgroundColor: "#FFFFFF",
+    borderColor: "#E2E8F0",
+    marginHorizontal: 14,
+  },
+  searchIcon: { fontSize: 14, marginRight: 8, opacity: 0.9 },
+  searchInput: { flex: 1, fontSize: 12, paddingVertical: 8, color: "#0B1220" },
+
+  card: {
+    backgroundColor: "#FFFFFF",
+    borderWidth: 1,
+    borderColor: "#E2E8F0",
+    borderRadius: 16,
+    padding: 12,
+    marginHorizontal: 14,
+    marginTop: 12,
   },
 
-  searchIcon: {
-    fontSize: 14,
-    marginRight: 8,
-    opacity: 0.8,
+  sectionHeaderRow: {
+    flexDirection: "row",
+    alignItems: "baseline",
+    justifyContent: "space-between",
+    marginBottom: 10,
   },
+  sectionTitleSmall: { fontSize: 12, fontWeight: "900", color: "#0B1220" },
+  sectionMetaSmall: { fontSize: 11, fontWeight: "700", color: "#64748B" },
 
-  searchInput: {
-    flex: 1,
-    fontSize: 14,
-    paddingVertical: 8,
+  quickGrid: { flexDirection: "row", flexWrap: "wrap", gap: 10 },
+  quickItem: { width: "30%", minWidth: 92, alignItems: "center", gap: 6, paddingVertical: 6 },
+  quickIcon: {
+    width: 52,
+    height: 52,
+    borderRadius: 26,
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: 1,
+    borderColor: "rgba(16,24,40,0.08)",
   },
+  quickEmoji: { fontSize: 20 },
+  quickLabel: { textAlign: "center", fontSize: 10, fontWeight: "800", color: "#0B1220", lineHeight: 13 },
 
-  chipsRow: {
-    paddingVertical: 2,
-    gap: 8,
-  },
-
+  chipsRow: { paddingVertical: 10, paddingHorizontal: 14, gap: 8 },
   chip: {
     paddingVertical: 8,
     paddingHorizontal: 12,
     borderRadius: 999,
     borderWidth: StyleSheet.hairlineWidth,
-    flexShrink: 0, // evita compressão -> evita "..."
+    flexShrink: 0,
   },
-
-  chipText: {
-    fontSize: 13,
-    fontWeight: "800",
-  },
+  chipText: { fontSize: 11, fontWeight: "800" },
 
   hero: {
-    marginTop: 8,
+    marginTop: 10,
     borderWidth: 1,
     borderRadius: 16,
     padding: 14,
     flexDirection: "row",
     gap: 12,
     alignItems: "center",
+    marginHorizontal: 14,
   },
-
-  heroTitle: {
-    fontSize: 16,
-    fontWeight: "900",
-    letterSpacing: -0.2,
-  },
-
-  heroDesc: {
-    fontSize: 13,
-    lineHeight: 18,
-  },
+  heroTitle: { fontSize: 14, fontWeight: "900", letterSpacing: -0.2 },
+  heroDesc: { fontSize: 11, lineHeight: 15 },
 
   heroActions: {
     flexDirection: "row",
@@ -362,12 +418,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     borderRadius: 12,
   },
-
-  btnPrimaryText: {
-    color: "#FFFFFF",
-    fontWeight: "900",
-    fontSize: 13,
-  },
+  btnPrimaryText: { color: "#FFFFFF", fontWeight: "900", fontSize: 12 },
 
   btnGhost: {
     paddingVertical: 10,
@@ -375,12 +426,7 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     backgroundColor: "rgba(148,163,184,0.15)",
   },
-
-  btnGhostText: {
-    color: "#0B1220",
-    fontWeight: "900",
-    fontSize: 13,
-  },
+  btnGhostText: { color: "#0B1220", fontWeight: "900", fontSize: 12 },
 
   heroNeutralBox: {
     width: 74,
@@ -392,30 +438,16 @@ const styles = StyleSheet.create({
   catalogHeader: {
     marginTop: 14,
     marginBottom: 6,
+    marginHorizontal: 14,
     flexDirection: "row",
     alignItems: "baseline",
     justifyContent: "space-between",
   },
 
-  sectionTitle: {
-    fontSize: 20,
-    fontWeight: "900",
-    letterSpacing: -0.2,
-  },
+  sectionTitle: { fontSize: 16, fontWeight: "900", letterSpacing: -0.2, color: "#0B1220" },
+  sectionMeta: { fontSize: 11, fontWeight: "700", color: "#64748B" },
 
-  sectionMeta: {
-    fontSize: 13,
-    fontWeight: "700",
-  },
+  grid: { marginTop: 10, gap: 12, paddingHorizontal: 14 },
 
-  grid: {
-    marginTop: 10,
-    gap: 12,
-  },
-
-  empty: {
-    marginTop: 10,
-    fontSize: 13,
-    fontWeight: "700",
-  },
+  empty: { marginTop: 10, fontSize: 11, fontWeight: "700", color: "#64748B" },
 });


### PR DESCRIPTION
O que muda
- Home com fundo branco e tipografia menor (letras/números menores).
- Campo de busca branco com placeholder/texto preto.
- Substitui o banner principal por um “meio banner” azul fixo no topo, contendo:
  - Área de endereço do comprador (stub)
  - Ícones de departamentos (scroll horizontal)
- Ao rolar a tela, a faixa azul permanece fixa.

Tracking
- home_search_focused (ao focar a busca)
- home_address_click (ao tocar no endereço)
- home_department_click (ao tocar em um departamento)

Como testar
1) Abra a aba Início.
2) Verifique: fundo branco, textos pretos, busca branca.
3) Role a tela: o header azul deve permanecer fixo.
4) Toque na busca: deve navegar para /search.
5) Toque em um departamento: navega para /explore (stub) e registra métrica.

Notas
- Endereço e rotas de departamento estão como stub (placeholder) e serão conectados ao perfil/endereço real depois.