### PR TITLE
feat(entry): redirect root to biometric gate

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,0 +1,26 @@
+// app/index.tsx
+import { Redirect } from "expo-router";
+import { useEffect, useMemo } from "react";
+
+import { isFlagEnabled } from "../constants/flags";
+import { track } from "../lib/analytics";
+
+export default function AppIndex() {
+  const enabled = useMemo(() => isFlagEnabled("ff_entry_default_gate_v1"), []);
+
+  useEffect(() => {
+    try {
+      track("entry_root_redirect_view", { enabled });
+    } catch {}
+  }, [enabled]);
+
+  const to = enabled ? "/entry/index" : "/(tabs)";
+
+  useEffect(() => {
+    try {
+      track("entry_root_redirect", { to });
+    } catch {}
+  }, [to]);
+
+  return <Redirect href={to as any} />;
+}

--- a/constants/flags.ts
+++ b/constants/flags.ts
@@ -21,6 +21,7 @@ export type FeatureFlag =
   | "ff_cart_ui_v2"
   | "ff_reviews_verified_purchase_v1"
   | "ff_entry_biometric_gate_v1"
+  | "ff_entry_default_gate_v1"
   | "ff_home_achadinhos_v1";
 
 const DEFAULT_FLAGS: Record<FeatureFlag, boolean> = {
@@ -52,6 +53,7 @@ const DEFAULT_FLAGS: Record<FeatureFlag, boolean> = {
   ff_reviews_verified_purchase_v1: false,
 
   ff_entry_biometric_gate_v1: true,
+  ff_entry_default_gate_v1: true,
 
   // Ticket 01 — Home Achadinhos do Dia
   ff_home_achadinhos_v1: false,


### PR DESCRIPTION
## What
- Add app/index.tsx to define "/" route and redirect into entry gate
- Add ff_entry_default_gate_v1 to typed flags + defaults

## Why
- Ensure app starts at biometric gate instead of falling directly into (tabs)

## Flags
- ff_entry_default_gate_v1

## Metrics
- entry_root_redirect_view
- entry_root_redirect

## Checklist
- [x] npm run ci
- [x] git diff main...HEAD --stat