### PR TITLE
fix(checkout): consolidate order draft storage

### DIFF
--- a/utils/orderDraftStorage.ts
+++ b/utils/orderDraftStorage.ts
@@ -1,0 +1,40 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import type { OrderDraft } from "../types/order";
+
+const KEY = "@plugaishop:order_draft";
+
+function safeJsonParse<T>(raw: string): T | null {
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveOrderDraft(order: OrderDraft): Promise<void> {
+  try {
+    await AsyncStorage.setItem(KEY, JSON.stringify(order));
+  } catch {
+    // best-effort: não quebra checkout
+  }
+}
+
+export async function loadOrderDraft(): Promise<OrderDraft | null> {
+  try {
+    const raw = await AsyncStorage.getItem(KEY);
+    if (!raw) return null;
+
+    const parsed = safeJsonParse<OrderDraft>(raw);
+    return parsed ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function clearOrderDraft(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(KEY);
+  } catch {
+    // best-effort
+  }
+}

--- a/utils/orderStorage.ts
+++ b/utils/orderStorage.ts
@@ -1,17 +1,2 @@
-import AsyncStorage from "@react-native-async-storage/async-storage";
-import type { OrderDraft } from "../types/order";
-
-const KEY = "@plugaishop:order_draft";
-
-export async function saveOrderDraft(order: OrderDraft) {
-  await AsyncStorage.setItem(KEY, JSON.stringify(order));
-}
-
-export async function loadOrderDraft(): Promise<OrderDraft | null> {
-  const data = await AsyncStorage.getItem(KEY);
-  return data ? JSON.parse(data) : null;
-}
-
-export async function clearOrderDraft() {
-  await AsyncStorage.removeItem(KEY);
-}
+// Compat wrapper (legacy name). Prefer importing from "./orderDraftStorage".
+export * from "./orderDraftStorage";


### PR DESCRIPTION
## What
- Consolidate order draft persistence into utils/orderDraftStorage.ts
- Keep utils/orderStorage.ts as a compat re-export (legacy import path)

## Why
- Avoid duplicate implementations and inconsistent imports
- Harden draft load against malformed JSON (no checkout crash)

## Checklist
- [x] npm run ci
- [x] git diff main...HEAD --stat