### PR TITLE
fix(checkout): use tabs routes to avoid shim redirects

### DIFF
--- a/app/(tabs)/checkout/payment.tsx
+++ b/app/(tabs)/checkout/payment.tsx
@@ -1,4 +1,3 @@
-// app/(tabs)/checkout/payment.tsx
 import { router } from "expo-router";
 import { useEffect, useMemo, useState } from "react";
 import { Pressable, Text, View } from "react-native";
@@ -28,7 +27,7 @@ export default function Payment() {
       ...order,
       payment: { method: "pix", status: "pending" },
     });
-    router.push("/checkout/review" as any);
+    router.push("/(tabs)/checkout/review" as any);
   }
 
   return (


### PR DESCRIPTION
## What
- Update internal checkout navigation in app/(tabs)/checkout/* to push directly to /(tabs)/checkout/*

## Why
- Avoid double redirects (tabs -> /checkout shim -> tabs) and reduce flicker/analytics noise
- Keep app/checkout/* shims only for deep link/compat

## Checklist
- [x] npm run ci
- [x] git diff main...HEAD --stat