### PR TITLE
fix(analytics): unify checkout shim redirect event

### DIFF
--- a/app/(tabs)/checkout/pix.tsx
+++ b/app/(tabs)/checkout/pix.tsx
@@ -1,7 +1,6 @@
-// app/(tabs)/checkout/pix.tsx
 import { Stack, useRouter } from "expo-router";
 import { useEffect } from "react";
-import { View, ActivityIndicator, StyleSheet } from "react-native";
+import { ActivityIndicator, StyleSheet, View } from "react-native";
 
 import { track } from "../../../lib/analytics";
 
@@ -9,10 +8,12 @@ export default function CheckoutPixShim() {
   const router = useRouter();
 
   useEffect(() => {
-    track("checkout.route_shim_redirect", {
-      from: "(tabs)/checkout/pix",
-      to: "(tabs)/checkout/payment",
-    });
+    try {
+      track("checkout_route_shim_redirect", {
+        from: "/(tabs)/checkout/pix",
+        to: "/(tabs)/checkout/payment",
+      });
+    } catch {}
 
     router.replace("/(tabs)/checkout/payment");
   }, [router]);


### PR DESCRIPTION
## What
- Standardize checkout pix shim analytics event name to checkout_route_shim_redirect
- Use absolute route strings for from/to

## Why
- Avoid fragmented metrics (checkout.route_shim_redirect vs checkout_route_shim_redirect)

## Checklist
- [x] npm run ci
- [x] git diff main...HEAD --stat